### PR TITLE
Stop type-checking for 'object' to allow functions as well

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -17,7 +17,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.4.3",
     "babel-runtime": "^6.3.19",
-    "babel-plugin-extensible-destructuring": "^4.0.0",
-    "extensible-runtime": "^4.0.0"
+    "babel-plugin-extensible-destructuring": "file:..",
+    "extensible-runtime": "file:../runtime"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "mocha": "^2.3.4",
     "bluebird": "^3.2.2",
     "immutable": "^3.7.5",
-    "extensible-runtime": "^4.0.0"
+    "extensible-runtime": "file:runtime"
   }
 }

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -10,9 +10,11 @@
     "watch": "npm run build -- --watch",
     "prepublish": "npm run clean && npm run build"
   },
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "immutable": "^3.7.6"
+  },
+  "devDependencies": {
+    "babel-cli": "6.24.1"
   }
 }

--- a/runtime/src/runtime.js
+++ b/runtime/src/runtime.js
@@ -29,13 +29,8 @@ export function normal(o, k, d) {
   if (typeof k !== 'string') {
     throw new Error(`cannot resolve non-string property ${type(k)} ${safeString(k)}`)
   }
-  if (typeof o !== 'object') {
-    throw new Error(`cannot resolve property ${k} in object of type ${typeof o} (${safeString(o)})`)
-  }
-  if (k in o) {
-    return o[k]
-  }
-  return d
+  const value = o[k]
+  return value !== undefined ? value : d
 };
 
 
@@ -46,34 +41,27 @@ export function immutable(o, k, d) {
   if (typeof k !== 'string') {
     throw new Error(`cannot resolve non-string property ${type(k)} ${safeString(k)}`)
   }
-  if (typeof o !== 'object') {
-    throw new Error(`cannot resolve property ${k} in object of type ${typeof o} (${safeString(o)})`)
-  }
-  if (k in o) {
-    return o[k]
-  }
-  return d
+  const value = o[k]
+  return value !== undefined ? value : d
 };
 
 export function safe(o, k, d) {
   if (Iterable.isIterable(o)) {
     let res = o.get(k, d)
     if (res === undefined) {
-      throw new Error(`Key Error: object with keys ${stringKeys(o)} does not contain property ${k}`)
+      throw new Error(`Key Error: object of type ${typeof o} with keys ${stringKeys(o)} does not contain property ${k}`)
     }
     return o.get(k, d)
   }
   if (typeof k !== 'string') {
     throw new Error(`cannot resolve non-string property ${type(k)} ${safeString(k)}`)
   }
-  if (typeof o !== 'object') {
-    throw new Error(`cannot resolve property ${k} in object of type ${typeof o} (${safeString(o)})`)
-  }
-  if (k in o) {
-    return o[k]
+  const value = o[k]
+  if (value !== undefined) {
+    return value
   }
   if (d === undefined) {
-    throw new Error(`Key Error: object with keys ${stringKeys(o)} does not contain property ${k}`)
+    throw new Error(`Key Error: object of type ${typeof o} with keys ${stringKeys(o)} does not contain property ${k}`)
   }
   return d
 }

--- a/runtime/src/runtime.js
+++ b/runtime/src/runtime.js
@@ -26,6 +26,9 @@ function type(o) {
 }
 
 export function normal(o, k, d) {
+  if (o === null || o === undefined) {
+    throw new Error(`cannot resolve property ${safeString(k)} of ${o}`)
+  }
   if (typeof k !== 'string') {
     throw new Error(`cannot resolve non-string property ${type(k)} ${safeString(k)}`)
   }
@@ -33,8 +36,10 @@ export function normal(o, k, d) {
   return value !== undefined ? value : d
 };
 
-
 export function immutable(o, k, d) {
+  if (o === null || o === undefined) {
+    throw new Error(`cannot resolve property ${safeString(k)} of ${o}`)
+  }
   if (Iterable.isIterable(o)) {
     return o.get(k, d)
   }
@@ -46,6 +51,9 @@ export function immutable(o, k, d) {
 };
 
 export function safe(o, k, d) {
+  if (o === null || o === undefined) {
+    throw new Error(`cannot resolve property ${safeString(k)} of ${o}`)
+  }
   if (Iterable.isIterable(o)) {
     let res = o.get(k, d)
     if (res === undefined) {

--- a/test/runtime/basics.js
+++ b/test/runtime/basics.js
@@ -1,8 +1,7 @@
 import assert from 'assert'
 import {fromJS} from 'immutable'
 
-const runtime = require('../../runtime')
-//import patch from '../../runtime'
+const runtime = require('extensible-runtime')
 
 describe('runtime basic behavior', () => {
 

--- a/test/runtime/basics.js
+++ b/test/runtime/basics.js
@@ -4,12 +4,36 @@ import {fromJS} from 'immutable'
 const runtime = require('extensible-runtime')
 
 describe('runtime basic behavior', () => {
-
   for (let mode of ['normal', 'immutable', 'safe']) {
-    it(`ok when found in mode ${mode}`, () => {
+    it(`ok with objects when found in mode ${mode}`, () => {
       var __extensible_get__ = runtime[mode] //eslint-disable-line
       let {a} = {a: 1}
       assert.equal(a, 1)
+    })
+
+    it(`ok with functions when found in mode ${mode}`, () => {
+      var __extensible_get__ = runtime[mode] //eslint-disable-line
+      let foo = () => {}
+      foo.a = 1
+      let {a} = foo
+      assert.equal(a, 1)
+    })
+
+    it(`ok with strings when found in mode ${mode}`, () => {
+      var __extensible_get__ = runtime[mode] //eslint-disable-line
+      let {length} = 'test'
+      assert.equal(length, 4)
+    })
+
+    it(`throws when undefined in mode ${mode}`, () => {
+      var __extensible_get__ = runtime[mode] //eslint-disable-line
+      let didThrow = false
+      try {
+        let {test} = undefined // eslint-disable-line no-unused-vars
+      } catch (e) {
+        didThrow = e.message.indexOf('cannot resolve') !== -1
+      }
+      assert.equal(didThrow, true)
     })
   }
 
@@ -31,17 +55,14 @@ describe('runtime default', () => {
 })
 
 describe('runtime immutable', () => {
-
   it('undefined when not found', () => {
     var __extensible_get__ = runtime['immutable'] //eslint-disable-line
     let {b} = fromJS({a: 1})
     assert.equal(b, undefined)
   })
-
 })
 
 describe('runtime safe', () => {
-
   it('throws when not found in js-obj', () => {
     var __extensible_get__ = runtime['safe'] //eslint-disable-line
     let good


### PR DESCRIPTION
Fixes https://github.com/vacuumlabs/babel-plugin-extensible-destructuring/issues/19.

~~No need to type check because we'd just re-throw anyway, and default error is pretty clear -- trying to invoke `'foo' in 'bar'` results in `Cannot use 'in' operator to search for 'foo' in bar` (at least with Chrome dev tools).~~

~~Let me know if you'd prefer to go a different route, e.g. check `typeof` for both `'object'` and `'function'`. Simply checking `instanceof Object` would be even better, but unfortunately Immutable tends to create its own `Object` that's different from the global one so that won't work.~~

See discussion below for more info.