### PR TITLE
Fixes for babel7 compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,17 @@ function _printNode(node, lvl, indent) {
 
 export default function({types: t}) {
 
+  /*
+    Babel 7 renamed RestProperty to RestElement.
+    Check which one is available, then make a copy of it for future references.
+  */
+  let isRestElement
+  if (t.isRestElement) {
+    isRestElement = t.isRestElement
+  } else {
+    isRestElement = t.isRestProperty
+  }
+
   function generateRequire(pkgName, methodName)  {
     return t.variableDeclaration(
       'var',
@@ -90,7 +101,7 @@ export default function({types: t}) {
 
   function hasRest(pattern) {
     for (let elem of pattern.elements) {
-      if (t.isRestElement(elem)) {
+      if (isRestElement(elem)) {
         return true
       }
     }
@@ -178,7 +189,7 @@ export default function({types: t}) {
         if (i >= spreadPropIndex) break
 
         // ignore other spread properties
-        if (t.isRestProperty(prop)) continue
+        if (isRestElement(prop)) continue
 
         let key = prop.key
         if (t.isIdentifier(key) && !prop.computed) key = t.stringLiteral(prop.key.name)
@@ -237,7 +248,7 @@ export default function({types: t}) {
 
       for (let i = 0; i < pattern.properties.length; i++) {
         let prop = pattern.properties[i]
-        if (t.isRestProperty(prop)) {
+        if (isRestElement(prop)) {
           this.pushObjectRest(pattern, objRef, prop, i)
         } else {
           this.pushObjectProperty(prop, objRef)
@@ -277,7 +288,7 @@ export default function({types: t}) {
     pushUnpackedArrayPattern(pattern, arr) {
       for (let i = 0; i < pattern.elements.length; i++) {
         let elem = pattern.elements[i]
-        if (t.isRestElement(elem)) {
+        if (isRestElement(elem)) {
           this.push(elem.argument, t.arrayExpression(arr.elements.slice(i)))
         } else {
           this.push(elem, arr.elements[i])
@@ -329,7 +340,7 @@ export default function({types: t}) {
 
         let elemRef
 
-        if (t.isRestElement(elem)) {
+        if (isRestElement(elem)) {
           elemRef = this.toArray(arrayRef)
 
           if (i > 0) {


### PR DESCRIPTION
Resubmit of [PR #23](https://github.com/vacuumlabs/babel-plugin-extensible-destructuring/pull/23), with some babel6 compatibility fixes. See [Issue #22](https://github.com/vacuumlabs/babel-plugin-extensible-destructuring/issues/22) for details.

Credit goes to @palnes for most of this PR.

 I pulled these changes into a babel6 project that uses extensible destructuring heavily and confirmed things are working there.